### PR TITLE
Fix misspellings, show user API error in message

### DIFF
--- a/src/classes/data/Data.js
+++ b/src/classes/data/Data.js
@@ -100,7 +100,7 @@ export default class Data extends LittleEvent {
         await this.updatePrompt(prompt, true);
     }
 
-    getAcitveNoteContent() {
+    getActiveNoteContent() {
         throwImplementationError();
     }
 

--- a/src/classes/data/Data.js
+++ b/src/classes/data/Data.js
@@ -180,7 +180,7 @@ export default class Data extends LittleEvent {
         throwImplementationError();
     }
 
-    async handleMsgCommand(command, msg) {
+    async handleMsgCommand(command, msg, engine) {
         debug(command, msg);
         const map = {
             copy: this.msgCopy.bind(this),
@@ -190,7 +190,7 @@ export default class Data extends LittleEvent {
             child: this.msgChild.bind(this),
         };
         if (map[command]) {
-            await map[command](msg);
+            await map[command](msg, engine);
         }
     }
 
@@ -211,8 +211,10 @@ export default class Data extends LittleEvent {
         await this.setNoteWith(msg, true);
     }
 
-    async msgChild(msg) {
-        await this.saveToChild(sliceTitle(msg), wrapP(msg));
+    async msgChild(msg, engine) {
+        const content = getFirstUserContentOrThrow(engine);
+
+        await this.saveToChild(content, wrapP(msg));
     }
 
     async handleSaveHistory(engine) {

--- a/src/classes/data/DataDev.js
+++ b/src/classes/data/DataDev.js
@@ -44,9 +44,9 @@ export default class DataDev extends Data {
         return setLocalItem(DATA_KEYS.CHAT_PROMPTS, DEFAULT_PROMPTS);
     }
 
-    async getAcitveNoteContent() {
+    async getActiveNoteContent() {
         await nap();
-        this.emit(EVENT_DATA.setStatus, { status: STATUS_DATA.faild, key: 'noteId', value: 'file' });
+        this.emit(EVENT_DATA.setStatus, { status: STATUS_DATA.failed, key: 'noteId', value: 'file' });
         showTooltip(TRILIUM_ONLY);
         throw new Error('not supported');
     }

--- a/src/classes/data/DataTrilium.js
+++ b/src/classes/data/DataTrilium.js
@@ -209,7 +209,7 @@ export default class DataTrilium extends Data {
      * provide two kinds of messages. engine for chatgpt, view for innerHtml
      * @returns {Promise}
      */
-    async getAcitveNoteContent() {
+    async getActiveNoteContent() {
         try {
             const activeNote = getSupportedActiveNoteOrThrow();
             const { content } = await activeNote.getNoteComplement();
@@ -220,8 +220,8 @@ export default class DataTrilium extends Data {
             };
         } catch (error) {
             this.emit(EVENT_DATA.setStatus, {
-                status: STATUS_DATA.faild,
-                key: 'acitveNote',
+                status: STATUS_DATA.failed,
+                key: 'activeNote',
                 value: error.message,
             });
             throwError(error.message);

--- a/src/classes/engine/ChatGpt.js
+++ b/src/classes/engine/ChatGpt.js
@@ -129,7 +129,7 @@ export default class ChatGpt extends LittleEvent {
 
         if (!this.apiKey) {
             this.replaceMessage(
-                'please config your apikey in options file and reload',
+                'Please verify your API Key is correct in the note titled "CHAT_OPTIONS", and then reload via (F5) or (Ctrl + R), or Trilium menu: Advanced > Reload Frontend',
                 STATUS_MESSAGE.failed,
                 ROLE.error
             );
@@ -144,7 +144,11 @@ export default class ChatGpt extends LittleEvent {
             }
         } catch (error) {
             console.error(error);
-            this.replaceMessage('API Error. See console logs for details.', STATUS_MESSAGE.failed, ROLE.error);
+            this.replaceMessage(
+                'API Error. See console logs for details. (ctrl + shift + i)',
+                STATUS_MESSAGE.failed,
+                ROLE.error
+            );
         }
     }
 

--- a/src/classes/engine/ChatGpt.js
+++ b/src/classes/engine/ChatGpt.js
@@ -115,7 +115,7 @@ export default class ChatGpt extends LittleEvent {
 
     async sendRequest(overrideOptions = {}) {
         const messages = this.thread.reduce((handleMessages, msg) => {
-            // title = msg.content;
+            // Maybe there's some way to set msg.content the title of the note instead?
             if (isMsgExpected(msg.status)) {
                 handleMessages.push({ role: msg.role, content: msg.content });
             }

--- a/src/classes/engine/ChatGpt.js
+++ b/src/classes/engine/ChatGpt.js
@@ -130,7 +130,7 @@ export default class ChatGpt extends LittleEvent {
         if (!this.apiKey) {
             this.replaceMessage(
                 'please config your apikey in options file and reload',
-                STATUS_MESSAGE.faild,
+                STATUS_MESSAGE.failed,
                 ROLE.error
             );
             return;
@@ -144,7 +144,7 @@ export default class ChatGpt extends LittleEvent {
             }
         } catch (error) {
             console.error(error);
-            this.replaceMessage('API Error. See console logs for details.', STATUS_MESSAGE.faild, ROLE.error);
+            this.replaceMessage('API Error. See console logs for details.', STATUS_MESSAGE.failed, ROLE.error);
         }
     }
 

--- a/src/classes/view/components/EleGenerate.js
+++ b/src/classes/view/components/EleGenerate.js
@@ -25,7 +25,7 @@ export default class EleGenerate extends LittleEvent {
     bindEngineEvents() {
         this.chatView.chatEngine.on(EVENT_ENGINE.setStatus, (status) => {
             this.toggleStopGenerating([STATUS_MESSAGE.generating, STATUS_MESSAGE.fetching].includes(status));
-            this.toggleRegenerate([STATUS_MESSAGE.cancel, STATUS_MESSAGE.faild].includes(status));
+            this.toggleRegenerate([STATUS_MESSAGE.cancel, STATUS_MESSAGE.failed].includes(status));
         });
     }
 

--- a/src/classes/view/components/EleGenerate.js
+++ b/src/classes/view/components/EleGenerate.js
@@ -10,7 +10,7 @@ export default class EleGenerate extends LittleEvent {
         this.$stop = view.$chatView.$qs('.thread_op_stop');
 
         this.$stop.addEventListener('click', () => {
-            view.chatEngine.cencelGenerating();
+            view.chatEngine.cancelGenerating();
         });
 
         this.$regenerate = view.$chatView.$qs('.thread_op_regenerate');

--- a/src/classes/view/components/EleInput.js
+++ b/src/classes/view/components/EleInput.js
@@ -29,7 +29,7 @@ export default class EleInput extends LittleEvent {
         });
 
         this.chatView.chatEngine.on(EVENT_ENGINE.setStatus, (status) => {
-            this.enableUserInput(status !== STATUS_MESSAGE.faild);
+            this.enableUserInput(status !== STATUS_MESSAGE.failed);
             this.handleMsgStatus(status);
         });
 
@@ -65,7 +65,7 @@ export default class EleInput extends LittleEvent {
             hint = 'Send(Enter to send, Shift+Enter to break line)';
         } else {
             this.$sendBtn.classList.add('freezed');
-            if (this.engineStatus === STATUS_MESSAGE.faild) {
+            if (this.engineStatus === STATUS_MESSAGE.failed) {
                 hint = 'Regenerating is worth a try';
             } else {
                 hint = 'Wait a moment';
@@ -152,7 +152,7 @@ export default class EleInput extends LittleEvent {
 
         if (regNote.test(parsedPrompt)) {
             try {
-                const { engine, view } = await this.chatView.chatData.getAcitveNoteContent();
+                const { engine, view } = await this.chatView.chatData.getActiveNoteContent();
 
                 msgEngine = msgEngine.replace(regNote, engine);
                 msgView = msgView.replace(regNote, view);

--- a/src/classes/view/components/ElePrompt.js
+++ b/src/classes/view/components/ElePrompt.js
@@ -49,7 +49,7 @@ export default class ElePrompt extends LittleEvent {
         this.ModalForm = new ModalFormWrapper({
             $content: this.$contentForm,
             $chatView: view.$chatView,
-            title: 'Add temlate',
+            title: 'Add prompt template',
         });
 
         this.prompts = [];
@@ -106,7 +106,7 @@ export default class ElePrompt extends LittleEvent {
         });
 
         this.$addBtn.addEventListener('click', async (e) => {
-            this.ModalForm.show(e, { title: 'Add temlate' });
+            this.ModalForm.show(e, { title: 'Add prompt template' });
         });
 
         this.$closeBtn.addEventListener('click', () => {
@@ -129,7 +129,7 @@ export default class ElePrompt extends LittleEvent {
 
                 if (type === 'edit') {
                     this.ModalForm.show(e, {
-                        title: 'Edit temlate',
+                        title: 'Edit prompt template',
                         formData: { 'prompt-name': target.name, 'prompt-content': target.content },
                         flagObj: target,
                     });

--- a/src/classes/view/components/EleStatus.js
+++ b/src/classes/view/components/EleStatus.js
@@ -5,7 +5,7 @@ const STATUS_ENGINE = {
     [STATUS_MESSAGE.fetching]: 'Thinking...',
     [STATUS_MESSAGE.generating]: 'Typing...',
     [STATUS_MESSAGE.success]: 'On standby',
-    [STATUS_MESSAGE.faild]: STATUS_MESSAGE.faild,
+    [STATUS_MESSAGE.failed]: STATUS_MESSAGE.failed,
     [STATUS_MESSAGE.cancel]: STATUS_MESSAGE.cancel,
 };
 

--- a/src/classes/view/components/EleThread.js
+++ b/src/classes/view/components/EleThread.js
@@ -29,7 +29,7 @@ export default class EleThread {
     }
 
     wrapFunction() {
-        this.scrolToBottom = throttle(this.scrolToBottom, 300);
+        this.scrollToBottom = throttle(this.scrollToBottom, 300);
     }
 
     bindMsgEvents() {
@@ -151,11 +151,11 @@ export default class EleThread {
 
         this.$threadMsgs.appendChild(msgDom);
 
-        this.scrolToBottom();
+        this.scrollToBottom();
         return msgDom;
     }
 
-    scrolToBottom() {
+    scrollToBottom() {
         this.$threadMsgs.scrollTop = 10e10;
     }
 
@@ -170,7 +170,7 @@ export default class EleThread {
         currentMsgDom.children[0].textContent = content.content;
 
         if (!this.isHovering) {
-            this.scrolToBottom();
+            this.scrollToBottom();
         }
     }
 

--- a/src/classes/view/components/EleThread.js
+++ b/src/classes/view/components/EleThread.js
@@ -110,7 +110,7 @@ export default class EleThread {
 
             const { chatData } = this.chatView;
             try {
-                await chatData.handleMsgCommand(command, this.clickedMsg);
+                await chatData.handleMsgCommand(command, this.clickedMsg, this.chatView.chatEngine);
                 showTooltip('success');
             } catch (error) {
                 showTooltip(`${command}:${error.message}`, true);

--- a/src/classes/view/styles/operate.less
+++ b/src/classes/view/styles/operate.less
@@ -61,6 +61,7 @@
 
         .operate_bottom {
             height: 30px;
+            font-size: 13px;
         }
     }
 }

--- a/src/classes/view/styles/thread.less
+++ b/src/classes/view/styles/thread.less
@@ -85,6 +85,7 @@
             color: var(--main-text-color);
             transform: translateX(-50%);
             transition: all 0.3s;
+            white-space: nowrap;
 
             &:hover {
                 border-color: var(--trilium-green);

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -57,7 +57,7 @@ export const EVENT_DATA = {
 export const STATUS_DATA = {
     optionSyncing: 'optionSyncing',
     success: 'success',
-    faild: 'faild',
+    failed: 'failed',
 };
 
 export const STATUS_MESSAGE = {
@@ -65,7 +65,7 @@ export const STATUS_MESSAGE = {
     fetching: 'fetching',
     generating: 'generating',
     success: 'success',
-    faild: 'faild',
+    failed: 'failed',
     cancel: 'cancel',
 };
 

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -65,7 +65,7 @@ export const STATUS_MESSAGE = {
     fetching: 'Fetching information for task.',
     generating: 'Generating information for task.',
     success: 'Successfully completed task.',
-    failed: 'Failed to complete task. Please try again, or view the console for more information. (ctrl + shift + i)',
+    failed: 'Failed to complete task, view the console for more information. (ctrl + shift + i)',
     cancel: 'Canceled task.',
 };
 

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -142,6 +142,12 @@ export const DEFAULT_PROMPTS = [
         content: 'Translate the following content to {{language:English|Chinese|Czech}} language: \n{{activeNote}}',
         order: 1,
     },
+    {
+        id: 'official-2',
+        name: 'summarizeNote',
+        content: 'Summarize the following content: \n{{activeNote}}',
+        order: 2,
+    },
 ];
 
 export const NOT_SUPPORTED = 'NOT SUPPORTED';

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -62,11 +62,11 @@ export const STATUS_DATA = {
 
 export const STATUS_MESSAGE = {
     none: 'none',
-    fetching: 'fetching',
-    generating: 'generating',
-    success: 'success',
-    failed: 'failed',
-    cancel: 'cancel',
+    fetching: 'Fetching information for task.',
+    generating: 'Generating information for task.',
+    success: 'Successfully completed task.',
+    failed: 'Failed to complete task. Please try again, or view the console for more information. (ctrl + shift + i)',
+    cancel: 'Canceled task.',
 };
 
 export const SHOW_CLASS_NAME = 'show';

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -65,7 +65,7 @@ export const STATUS_MESSAGE = {
     fetching: 'Fetching information for task.',
     generating: 'Generating information for task.',
     success: 'Successfully completed task.',
-    failed: 'Failed to complete task, view the console for more information. (ctrl + shift + i)',
+    failed: 'Failed, view the console for more information. (ctrl + shift + i)',
     cancel: 'Canceled task.',
 };
 

--- a/src/template.html
+++ b/src/template.html
@@ -78,8 +78,8 @@
             <div class="thread">
                 <div class="thread-messages"></div>
 
-                <button class="thread_op thread_op_stop">stop generating</button>
-                <button class="thread_op thread_op_regenerate">regenerate</button>
+                <button class="thread_op thread_op_stop">Stop generating</button>
+                <button class="thread_op thread_op_regenerate">Retry/Regenerate Output</button>
 
                 <div class="msg-command">
                     <div class="command_item" command="copy" title="Copy">Copy</div>


### PR DESCRIPTION
Hi @soulsands,

Thanks again for making this great widget! I wanted to try my hand at fixing some of the misspellings in the code and those that are also user-facing.

- Fixed function names.
- Fixed user-facing strings.
- Show user the API error, if/when there is one.

I also tried my hand at figuring out why `appending` messages to notes saved the formatting versus using the `child` command to create a new child note with GPT output. It seems that the `createNewNote` backend function doesn't translate newline characters, or any markdown characters for that reason (which I'm sure you already know)...

I also tried to see if there was some way to set the title of the note (after running the `child` command) to the initial prompt that was sent to establish the GPT thread, but I wasn't able to figure out how to do so :(

I also wasn't able to fix the Bootstrap spacing underneath the "Send a message..." box, I'm honestly horrible at JavaScript but I wanted to try to help lol.
![image](https://github.com/soulsands/trilium-chat/assets/2390633/35837964-311c-4003-8bf3-77e8a8739a34)

Hopefully you find this PR helpful! Feel free to make any changes you see fit, or to just toss it in the trash lol. Have a good day :) 