### PR TITLE
Add Ollama use

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,19 @@ Options is stored in a JSON note with `#CHAT_OPTIONS ` label.
 | systemPrompt  | Background prompt used for system messages, e.g., set it to: "You are a helpful assistant for Trilium note-taking." | ‘’                                                           |
 | checkUpdates  | Whether to automatically check for updates. If enabled, a dot will be displayed on the face icon when an update is available. | true                                                         |
 
+### Use with Ollama
+
+If you want to use your own locally hosted [Ollama](https://github.com/ollama/ollama), you need to set the values of `requestUrls.completion` to `https://<your-endpoint>/api/chat`, set `stream` to `false`, and set `model` to whichever model you want to use from your Ollama:
+```json
+	"requestUrls": {
+		"completion": "https://ollama.local/api/chat"
+	},
+	"engineOptions": {
+		"model": "llama3",
+		"stream": false
+	},
+```
+
 ### Prompt
 
 The prompt supports customizable options, making it highly flexible to use.

--- a/README.md
+++ b/README.md
@@ -2,13 +2,16 @@
 
 ## Introduction
 
-The chat plugin highly integrated with Trilium.
+This chat plugin is highly integrated with Trilium, and allows you to access ChatGPT right inside Trilium!
+
+You can even use your own locally hosted Ollama.
 
 This project is written in vanilla JavaScript, and is a frontend-only project. For those interested in developing Trilium plugins, there are some details within that can be referenced.
 
 ## Features
 
 -   Normal chat
+-   Use Ollama
 -   Custom prompt
     -   Supports mustache syntax to render options. e.g. {{language:Enligsh|Chinese|Czech}} will be rendered as a select element (This can be changed in CHAT_PROMPTS) 
     -   {{message}} as your message
@@ -80,7 +83,7 @@ If you want to use your own locally hosted [Ollama](https://github.com/ollama/ol
 	"engineOptions": {
 		"model": "llama3",
 		"stream": false
-	},
+	}
 ```
 
 ### Prompt

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "trilium-chat",
-    "version": "0.4.4",
+    "version": "0.4.5",
     "description": "The chat plugin highly integrated with Trilium.",
     "keywords": [],
     "license": "AGPL-3.0-only",

--- a/src/classes/engine/ChatGpt.js
+++ b/src/classes/engine/ChatGpt.js
@@ -259,7 +259,8 @@ export default class ChatGpt extends LittleEvent {
             },
             body: JSON.stringify(options),
         });
-        const { content } = (await response.json()).choices[0].message;
+        const responseJson = await response.json();
+        const { content } = responseJson.choices ? responseJson.choices[0].message : responseJson.message;
 
         return content;
     }


### PR DESCRIPTION
This PR adds functionality and documentation about using Ollama instead of OpenAI's API. The user will of course need their own Ollama instance, but this allows them to keep all their LLM traffic local, and even to use their own custom built LLMs. 